### PR TITLE
Add "Inverted Logic" Option for Lights

### DIFF
--- a/custom_components/gpio_integration/_devices.py
+++ b/custom_components/gpio_integration/_devices.py
@@ -97,12 +97,15 @@ class BinarySensor(AsStringMixin, DigitalInputDevice):
 
 
 class RgbLight(RGBLED):
-    def __init__(self, red: int, green: int, blue: int, initial_value=(0, 0, 0)):
+    def __init__(
+        self, red: int, green: int, blue: int, active_high=True, initial_value=(0, 0, 0)
+    ):
         super().__init__(
             red,
             green,
             blue,
             pin_factory=get_pin_factory(),
+            active_high=active_high,
             initial_value=initial_value,
         )
 

--- a/custom_components/gpio_integration/config_flow.py
+++ b/custom_components/gpio_integration/config_flow.py
@@ -55,62 +55,50 @@ CONF_ENTITIES: dict = {
     EntityTypes.COVER.value: {
         "schema": COVER_VARIATION_SCHEMA,
         "validate": validate_cover_variation_data,
-        "schema_builder": create_cover_variation_schema,
     },
     EntityTypes.COVER_UP_DOWN.value: {
         "schema": COVER_UP_DOWN_SCHEMA,
         "validate": validate_cover_up_down_data,
-        "schema_builder": create_cover_up_down_schema,
     },
     EntityTypes.COVER_TOGGLE.value: {
         "schema": COVER_TOGGLE_SCHEMA,
         "validate": validate_toggle_cover_data,
-        "schema_builder": create_toggle_cover_schema,
     },
     EntityTypes.BINARY_SENSOR.value: {
         "schema": BINARY_SENSOR_SCHEMA,
         "validate": validate_binary_sensor_data,
-        "schema_builder": create_binary_sensor_schema,
     },
     EntityTypes.SWITCH.value: {
         "schema": SWITCH_SCHEMA,
         "validate": validate_switch_data,
-        "schema_builder": create_switch_schema,
     },
     EntityTypes.LIGHT.value: {
         "schema": LIGHT_VARIATION_SCHEMA,
         "validate": validate_light_variation_data,
-        "schema_builder": create_light_variation_schema,
     },
     EntityTypes.LIGHT_PWM_LED.value: {
         "schema": LIGHT_SCHEMA,
         "validate": validate_pwm_data,
-        "schema_builder": create_pwm_schema,
     },
     EntityTypes.LIGHT_RGB_LED.value: {
         "schema": RGB_LIGHT_SCHEMA,
         "validate": validate_rgb_light_data,
-        "schema_builder": create_rgb_light_schema,
     },
     EntityTypes.FAN.value: {
         "schema": FAN_SCHEMA,
         "validate": validate_pwm_data,
-        "schema_builder": create_pwm_schema,
     },
     EntityTypes.SENSOR.value: {
         "schema": SENSOR_VARIATION_SCHEMA,
         "validate": validate_sensor_variation_data,
-        "schema_builder": create_sensor_variation_schema,
     },
     EntityTypes.SENSOR_DHT22.value: {
         "schema": SENSOR_DHT22_SCHEMA,
         "validate": validate_sensor_dht22_data,
-        "schema_builder": create_sensor_dht22_schema,
     },
     EntityTypes.SENSOR_ANALOG_STEP.value: {
         "schema": SENSOR_ANALOG_STEP_SCHEMA,
         "validate": validate_sensor_analog_step_data,
-        "schema_builder": create_sensor_analog_step_schema,
     },
 }
 

--- a/custom_components/gpio_integration/config_flow.py
+++ b/custom_components/gpio_integration/config_flow.py
@@ -250,8 +250,10 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
             else:
                 data_clone = data.copy()
                 data_clone["unique_id"] = unique_id or ""
-                edit_schema = entity_info.get("schema_builder")(data_clone)
-
+                base_schema = entity_info.get("schema")
+                edit_schema = self.add_suggested_values_to_schema(
+                    base_schema, data_clone
+                )
                 return self.async_show_form(step_id="init", data_schema=edit_schema)
         else:
             errors["base"] = "unknown_type"

--- a/custom_components/gpio_integration/fan.py
+++ b/custom_components/gpio_integration/fan.py
@@ -45,7 +45,10 @@ class GpioFan(ClosableMixin, ReprMixin, FanEntity):
             raise ValueError("Frequency must be greater than 0")
 
         self._io = PwmFromPercent(
-            config.port, frequency=config.frequency, initial_value=config.default_state
+            config.port,
+            frequency=config.frequency,
+            active_high=not config.invert_logic,
+            initial_value=config.default_state,
         )
 
     @property

--- a/custom_components/gpio_integration/hub.py
+++ b/custom_components/gpio_integration/hub.py
@@ -1,7 +1,5 @@
 from homeassistant.const import Platform
 
-from custom_components.gpio_integration.schemas.light import RgbLightConfig
-
 from .controllers.cover import Roller
 from .controllers.sensor import AnalogStepControl, DHT22Controller
 from .core import get_logger
@@ -9,6 +7,7 @@ from .schemas.binary_sensor import BinarySensorConfig
 from .schemas.cover import RollerConfig, ToggleRollerConfig
 from .schemas.main import EntityTypes
 from .schemas.pwm import PwmConfig
+from .schemas.light import RgbLightConfig
 from .schemas.sensor import AnalogStepConfig, DHT22Config
 from .schemas.switch import SwitchConfig
 

--- a/custom_components/gpio_integration/hub.py
+++ b/custom_components/gpio_integration/hub.py
@@ -1,13 +1,16 @@
+import voluptuous as vol
+
 from homeassistant.const import Platform
 
+from .config_flow import CONF_ENTITIES
 from .controllers.cover import Roller
 from .controllers.sensor import AnalogStepControl, DHT22Controller
 from .core import get_logger
 from .schemas.binary_sensor import BinarySensorConfig
 from .schemas.cover import RollerConfig, ToggleRollerConfig
+from .schemas.light import RgbLightConfig
 from .schemas.main import EntityTypes
 from .schemas.pwm import PwmConfig
-from .schemas.light import RgbLightConfig
 from .schemas.sensor import AnalogStepConfig, DHT22Config
 from .schemas.switch import SwitchConfig
 
@@ -22,6 +25,26 @@ class Hub:
 
         self._type = EntityTypes(configs["type"])
         _LOGGER.debug('Hub: type "%s"', self._type.name)
+
+        if self._type is not None and configs:
+            # If we have config and a valid type, then try to
+            # add in any missing optional values from the base
+            # schema.
+            base_schema = CONF_ENTITIES[self._type.value]["schema"]
+            configs = dict(configs)
+            for key, val in base_schema.schema.items():
+                # Skip anything not an optional key
+                if not isinstance(key, vol.Optional):
+                    continue
+                # If not present in config data, copy in default
+                if key.schema not in configs:
+                    defVal = key.default()
+                    _LOGGER.debug(
+                        'Hub: setting missing default for config "%s" to value "%s"',
+                        key.schema,
+                        defVal,
+                    )
+                    configs.setdefault(key.schema, defVal)
 
         if self.is_type(EntityTypes.COVER_UP_DOWN):
             self.config = RollerConfig(configs)

--- a/custom_components/gpio_integration/light.py
+++ b/custom_components/gpio_integration/light.py
@@ -118,10 +118,17 @@ class GpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
 
         if self._pwm:
             self._io = Pwm(
-                config.port, config.frequency, initial_value=config.default_state
+                config.port,
+                config.frequency,
+                active_high=not config.invert_logic,
+                initial_value=config.default_state,
             )
         else:
-            self._io = Switch(config.port, initial_value=config.default_state)
+            self._io = Switch(
+                config.port,
+                active_high=not config.invert_logic,
+                initial_value=config.default_state,
+            )
 
         self._brightness = HIGH_BRIGHTNESS if config.default_state else 0
 
@@ -199,6 +206,7 @@ class RgbGpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
             config.port_red,
             config.port_green,
             config.port_blue,
+            active_high=not config.invert_logic,
             initial_value=(1, 1, 1) if config.default_state else (0, 0, 0),
         )
 

--- a/custom_components/gpio_integration/schemas/binary_sensor.py
+++ b/custom_components/gpio_integration/schemas/binary_sensor.py
@@ -22,17 +22,17 @@ def create_binary_sensor_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_PORT,
                 default=data[CONF_PORT],
-                description="GPIO pin number for the sensor",
+                description={"comment": "GPIO pin number for the sensor"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_BOUNCE_TIME,
                 default=data[CONF_BOUNCE_TIME],
-                description="Bounce time for the sensor in milliseconds",
+                description={"comment": "Bounce time for the sensor in milliseconds"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_INVERT_LOGIC,
                 default=data[CONF_INVERT_LOGIC],
-                description="Invert the logic of the sensor",
+                description={"comment": "Invert the logic of the sensor"},
             ): cv.boolean,
             vol.Required(CONF_MODE, default=data[CONF_MODE]): dropdown(
                 [

--- a/custom_components/gpio_integration/schemas/cover.py
+++ b/custom_components/gpio_integration/schemas/cover.py
@@ -53,22 +53,22 @@ def create_cover_up_down_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_RELAY_CLOSE_PIN,
                 default=data[CONF_RELAY_CLOSE_PIN],
-                description="GPIO pin number for the close relay",
+                description={"comment": "GPIO pin number for the close relay"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_RELAY_CLOSE_INVERT,
                 default=data[CONF_RELAY_CLOSE_INVERT],
-                description="Invert the logic of the close relay",
+                description={"comment": "Invert the logic of the close relay"},
             ): cv.boolean,
             vol.Required(
                 CONF_RELAY_OPEN_PIN,
                 default=data[CONF_RELAY_OPEN_PIN],
-                description="GPIO pin number for the open relay",
+                description={"comment": "GPIO pin number for the open relay"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_RELAY_OPEN_INVERT,
                 default=data[CONF_RELAY_OPEN_INVERT],
-                description="Invert the logic of the open relay",
+                description={"comment": "Invert the logic of the open relay"},
             ): cv.boolean,
             vol.Optional(
                 CONF_RELAY_TIME, default=data[CONF_RELAY_TIME]
@@ -138,12 +138,12 @@ def create_toggle_cover_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_PORT,
                 default=data[CONF_PORT],
-                description="GPIO pin number for the toggle button",
+                description={"comment": "GPIO pin number for the toggle button"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_INVERT_LOGIC,
                 default=data[CONF_INVERT_LOGIC],
-                description="Invert the logic of the toggle button",
+                description={"comment": "Invert the logic of the toggle button"},
             ): cv.boolean,
             vol.Optional(
                 CONF_RELAY_TIME, default=data[CONF_RELAY_TIME]

--- a/custom_components/gpio_integration/schemas/fan.py
+++ b/custom_components/gpio_integration/schemas/fan.py
@@ -5,6 +5,7 @@ from homeassistant.const import CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 from . import (
     CONF_DEFAULT_STATE,
     CONF_FREQUENCY,
+    CONF_INVERT_LOGIC,
 )
 from .pwm import create_pwm_schema
 
@@ -14,6 +15,7 @@ FAN_SCHEMA = create_pwm_schema(
         CONF_PORT: None,
         CONF_FREQUENCY: 100,
         CONF_DEFAULT_STATE: False,
+        CONF_INVERT_LOGIC: False,
         CONF_UNIQUE_ID: "",
     }
 )

--- a/custom_components/gpio_integration/schemas/light.py
+++ b/custom_components/gpio_integration/schemas/light.py
@@ -6,6 +6,7 @@ from homeassistant.const import CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 
 from . import (
     CONF_DEFAULT_STATE,
+    CONF_INVERT_LOGIC,
     CONF_FREQUENCY,
     EMPTY_VARIATION_DATA,
     create_variation_list_schema,
@@ -42,6 +43,7 @@ LIGHT_SCHEMA = create_pwm_schema(
         CONF_PORT: None,
         CONF_FREQUENCY: 0,
         CONF_DEFAULT_STATE: False,
+        CONF_INVERT_LOGIC: False,
         CONF_UNIQUE_ID: "",
     }
 )
@@ -82,6 +84,11 @@ def create_rgb_light_schema(data: dict) -> vol.Schema:
                 default=data[CONF_DEFAULT_STATE],
                 description="Default state of the light",
             ): cv.boolean,
+            vol.Optional(
+                CONF_INVERT_LOGIC,
+                default=data[CONF_INVERT_LOGIC],
+                description="Invert the logic of the LED (low = on)",
+            ): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID, default=data[CONF_UNIQUE_ID]): cv.string,
         }
     )
@@ -95,6 +102,7 @@ RGB_LIGHT_SCHEMA = create_rgb_light_schema(
         CONF_BLUE_PIN: None,
         CONF_FREQUENCY: 200,
         CONF_DEFAULT_STATE: False,
+        CONF_INVERT_LOGIC: False,
         CONF_UNIQUE_ID: "",
     }
 )
@@ -110,7 +118,7 @@ def validate_rgb_light_data(data):
 
 
 class RgbLightConfig:
-    """Switch configuration schema."""
+    """RGB Light configuration schema."""
 
     def __init__(self, data: dict):
         self.name: str = data[CONF_NAME]
@@ -119,4 +127,5 @@ class RgbLightConfig:
         self.port_blue: int = data[CONF_BLUE_PIN]
         self.frequency: int = data[CONF_FREQUENCY]
         self.default_state: bool = data[CONF_DEFAULT_STATE]
+        self.invert_logic: bool = data[CONF_INVERT_LOGIC]
         self.unique_id: str = get_unique_id(data)

--- a/custom_components/gpio_integration/schemas/light.py
+++ b/custom_components/gpio_integration/schemas/light.py
@@ -127,5 +127,8 @@ class RgbLightConfig:
         self.port_blue: int = data[CONF_BLUE_PIN]
         self.frequency: int = data[CONF_FREQUENCY]
         self.default_state: bool = data[CONF_DEFAULT_STATE]
-        self.invert_logic: bool = data[CONF_INVERT_LOGIC]
+        if CONF_INVERT_LOGIC in data:
+            self.invert_logic: bool = data[CONF_INVERT_LOGIC]
+        else:
+            self.invert_logic: bool = False
         self.unique_id: str = get_unique_id(data)

--- a/custom_components/gpio_integration/schemas/light.py
+++ b/custom_components/gpio_integration/schemas/light.py
@@ -1,13 +1,14 @@
 """Schema for the Light entities."""
 
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 
 from . import (
     CONF_DEFAULT_STATE,
-    CONF_INVERT_LOGIC,
     CONF_FREQUENCY,
+    CONF_INVERT_LOGIC,
     EMPTY_VARIATION_DATA,
     create_variation_list_schema,
     get_unique_id,
@@ -127,8 +128,5 @@ class RgbLightConfig:
         self.port_blue: int = data[CONF_BLUE_PIN]
         self.frequency: int = data[CONF_FREQUENCY]
         self.default_state: bool = data[CONF_DEFAULT_STATE]
-        if CONF_INVERT_LOGIC in data:
-            self.invert_logic: bool = data[CONF_INVERT_LOGIC]
-        else:
-            self.invert_logic: bool = False
+        self.invert_logic: bool = data[CONF_INVERT_LOGIC]
         self.unique_id: str = get_unique_id(data)

--- a/custom_components/gpio_integration/schemas/light.py
+++ b/custom_components/gpio_integration/schemas/light.py
@@ -62,32 +62,32 @@ def create_rgb_light_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_RED_PIN,
                 default=data[CONF_RED_PIN],
-                description="GPIO pin number for red color",
+                description={"comment": "GPIO pin number for red color"},
             ): cv.positive_int,
             vol.Required(
                 CONF_GREEN_PIN,
                 default=data[CONF_GREEN_PIN],
-                description="GPIO pin number for green color",
+                description={"comment": "GPIO pin number for green color"},
             ): cv.positive_int,
             vol.Required(
                 CONF_BLUE_PIN,
                 default=data[CONF_BLUE_PIN],
-                description="GPIO pin number for blue color",
+                description={"comment": "GPIO pin number for blue color"},
             ): cv.positive_int,
             vol.Required(
                 CONF_FREQUENCY,
                 default=data[CONF_FREQUENCY],
-                description="The light pulse frequency",
+                description={"comment": "The light pulse frequency"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_DEFAULT_STATE,
                 default=data[CONF_DEFAULT_STATE],
-                description="Default state of the light",
+                description={"comment": "Default state of the light"},
             ): cv.boolean,
             vol.Optional(
                 CONF_INVERT_LOGIC,
                 default=data[CONF_INVERT_LOGIC],
-                description="Invert the logic of the LED (low = on)",
+                description={"comment": "Invert the logic of the LED (low = on)"},
             ): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID, default=data[CONF_UNIQUE_ID]): cv.string,
         }

--- a/custom_components/gpio_integration/schemas/pwm.py
+++ b/custom_components/gpio_integration/schemas/pwm.py
@@ -47,5 +47,8 @@ class PwmConfig:
         self.port: int = data[CONF_PORT]
         self.frequency: int = data[CONF_FREQUENCY]
         self.default_state: bool = data[CONF_DEFAULT_STATE]
-        self.invert_logic: bool = data[CONF_INVERT_LOGIC]
+        if CONF_INVERT_LOGIC in data:
+            self.invert_logic: bool = data[CONF_INVERT_LOGIC]
+        else:
+            self.invert_logic: bool = False
         self.unique_id: str = get_unique_id(data)

--- a/custom_components/gpio_integration/schemas/pwm.py
+++ b/custom_components/gpio_integration/schemas/pwm.py
@@ -4,7 +4,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.const import CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 
-from . import CONF_DEFAULT_STATE, CONF_FREQUENCY, get_unique_id
+from . import CONF_DEFAULT_STATE, CONF_FREQUENCY, CONF_INVERT_LOGIC, get_unique_id
 from ._validators import v_name, v_pin
 
 
@@ -27,6 +27,11 @@ def create_pwm_schema(data: dict) -> vol.Schema:
                 default=data[CONF_DEFAULT_STATE],
                 description="Default state",
             ): cv.boolean,
+            vol.Optional(
+                CONF_INVERT_LOGIC,
+                default=data[CONF_INVERT_LOGIC],
+                description="Invert the logic of the output (low = on)",
+            ): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID, default=data[CONF_UNIQUE_ID]): cv.string,
         }
     )
@@ -42,4 +47,5 @@ class PwmConfig:
         self.port: int = data[CONF_PORT]
         self.frequency: int = data[CONF_FREQUENCY]
         self.default_state: bool = data[CONF_DEFAULT_STATE]
+        self.invert_logic: bool = data[CONF_INVERT_LOGIC]
         self.unique_id: str = get_unique_id(data)

--- a/custom_components/gpio_integration/schemas/pwm.py
+++ b/custom_components/gpio_integration/schemas/pwm.py
@@ -15,22 +15,22 @@ def create_pwm_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_PORT,
                 default=data[CONF_PORT],
-                description="GPIO pin number for the switch",
+                description={"comment": "GPIO pin number for the switch"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_FREQUENCY,
                 default=data[CONF_FREQUENCY],
-                description="The light pulse frequency (for LED)",
+                description={"comment": "The light pulse frequency (for LED)"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_DEFAULT_STATE,
                 default=data[CONF_DEFAULT_STATE],
-                description="Default state",
+                description={"comment": "Default state"},
             ): cv.boolean,
             vol.Optional(
                 CONF_INVERT_LOGIC,
                 default=data[CONF_INVERT_LOGIC],
-                description="Invert the logic of the output (low = on)",
+                description={"comment": "Invert the logic of the output (low = on)"},
             ): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID, default=data[CONF_UNIQUE_ID]): cv.string,
         }

--- a/custom_components/gpio_integration/schemas/pwm.py
+++ b/custom_components/gpio_integration/schemas/pwm.py
@@ -1,7 +1,8 @@
 """Schema for GPIO outputs using Pulse-Wide Modulation PWM."""
 
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 
 from . import CONF_DEFAULT_STATE, CONF_FREQUENCY, CONF_INVERT_LOGIC, get_unique_id
@@ -47,8 +48,5 @@ class PwmConfig:
         self.port: int = data[CONF_PORT]
         self.frequency: int = data[CONF_FREQUENCY]
         self.default_state: bool = data[CONF_DEFAULT_STATE]
-        if CONF_INVERT_LOGIC in data:
-            self.invert_logic: bool = data[CONF_INVERT_LOGIC]
-        else:
-            self.invert_logic: bool = False
+        self.invert_logic: bool = data[CONF_INVERT_LOGIC]
         self.unique_id: str = get_unique_id(data)

--- a/custom_components/gpio_integration/schemas/sensor.py
+++ b/custom_components/gpio_integration/schemas/sensor.py
@@ -46,7 +46,7 @@ def create_sensor_dht22_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_PORT,
                 default=data[CONF_PORT],
-                description="GPIO pin number for the switch",
+                description={"comment": "GPIO pin number for the switch"},
             ): cv.positive_int,
             vol.Optional(CONF_UNIQUE_ID, default=data[CONF_UNIQUE_ID]): cv.string,
         }

--- a/custom_components/gpio_integration/schemas/switch.py
+++ b/custom_components/gpio_integration/schemas/switch.py
@@ -19,17 +19,17 @@ def create_switch_schema(data: dict) -> vol.Schema:
             vol.Required(
                 CONF_PORT,
                 default=data[CONF_PORT],
-                description="GPIO pin number for the switch",
+                description={"comment": "GPIO pin number for the switch"},
             ): cv.positive_int,
             vol.Optional(
                 CONF_INVERT_LOGIC,
                 default=data[CONF_INVERT_LOGIC],
-                description="Invert the logic of the switch",
+                description={"comment": "Invert the logic of the switch"},
             ): cv.boolean,
             vol.Optional(
                 CONF_DEFAULT_STATE,
                 default=data[CONF_DEFAULT_STATE],
-                description="Default state of the switch",
+                description={"comment": "Default state of the switch"},
             ): cv.boolean,
             vol.Optional(CONF_UNIQUE_ID, default=data[CONF_UNIQUE_ID]): cv.string,
         }

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -5,6 +5,7 @@ from homeassistant.const import CONF_PORT
 from custom_components.gpio_integration.light import GpioLight
 from custom_components.gpio_integration.schemas import (
     CONF_DEFAULT_STATE,
+    CONF_INVERT_LOGIC,
     CONF_FREQUENCY,
     CONF_NAME,
 )
@@ -12,13 +13,14 @@ from custom_components.gpio_integration.schemas.pwm import PwmConfig
 from tests.mocks import get_next_pin
 
 
-def __create_config(port=None, default_state=False, frequency=50):
+def __create_config(port=None, default_state=False, frequency=50, invert_logic=False):
     return PwmConfig(
         {
             CONF_NAME: "Test Name",
             CONF_PORT: get_next_pin() if port is None else port,
             CONF_FREQUENCY: frequency,
             CONF_DEFAULT_STATE: default_state,
+            CONF_INVERT_LOGIC: invert_logic,
         }
     )
 
@@ -52,6 +54,13 @@ def test__GpioLight_LED_should_init_default_state(mocked_factory):
         assert gpio.is_on is True
         assert gpio.brightness == 255
         assert gpio.ha_state_update_scheduled is False
+
+
+def test__GpioLight_LED_should_init_invert(mocked_factory):
+    number = get_next_pin()
+    pin = mocked_factory.pin(number)
+    with GpioLight(__create_config(number, invert_logic=True, default_state=True)):
+        pin.assert_states([False])
 
 
 def test__GpioLight_LED_should_turn_led_on_off(mocked_factory):


### PR DESCRIPTION
This PR makes use of the CONF_INVERTED_LOGIC setting that's already used by Switches to allow setting whether a Light has inverted logic too. Default is to not invert to ensure the same behaviour as before.

The config was added to both the `PwmConfig` and `RgbLightConfig` classes to allow LEDs that are inverted in both the the Light variants. This also means by extension it will also be available for Fans too (seemed reasonable enough so as not to need a new `PwmLightConfig` class).

As with switches, the value of this config parameter is used to control whether the `active_high` parameter in gpiozero is set true or false.

I've also modified the `RgbLight` device class to allow feeding through the `active_high` parameter needed for this to work for the RGB variant of the Light.


Given this uses an existing config option, the language translations should not need to have anything added for this to work as the existing text is perfectly applicable.

I haven't tested this yet, still need to figure out how to test it in HA. Also I don't know enough about how the configuration screens in HA are generated as to whether anything needs to be added, or if the changes I've made will automatically cause a check box to appear.

Fixes #9 .