### PR TITLE
fix(#8): Fix object has no attribute '_blink_off' and add tests

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -8,7 +8,7 @@
         "LICENSE",
         "manifest.json",
         "extensions.json",
-        "translations/pt.json"
+        "**/translations/pt.json"
     ],
     "words": [
         "gpiozero",

--- a/custom_components/gpio_integration/_devices.py
+++ b/custom_components/gpio_integration/_devices.py
@@ -97,14 +97,21 @@ class BinarySensor(AsStringMixin, DigitalInputDevice):
 
 
 class RgbLight(RGBLED):
-    def __init__(self, red: int, green: int, blue: int, initial_value=(0, 0, 0)):
+    def __init__(
+        self, red: int, green: int, blue: int, frequency=100, initial_value=(0, 0, 0)
+    ):
         super().__init__(
             red,
             green,
             blue,
             pin_factory=get_pin_factory(),
             initial_value=initial_value,
+            pwm=frequency > 0,
         )
+        # When RGB light is PWM and the frequency is not the default 100Hz
+        if frequency > 0 and frequency != 100:
+            for x in self._leds:
+                x.frequency = frequency
 
     def __repr__(self):
         return f"{self.red!r}, {self.green!r}, {self.blue!r}"

--- a/custom_components/gpio_integration/_devices.py
+++ b/custom_components/gpio_integration/_devices.py
@@ -1,3 +1,4 @@
+# cspell:ignore leds
 from collections import deque, namedtuple
 from threading import RLock
 from typing import Callable, Literal

--- a/custom_components/gpio_integration/light.py
+++ b/custom_components/gpio_integration/light.py
@@ -65,7 +65,10 @@ def brightness_to_value(brightness: int) -> int:
 class BlinkMixin:
     @property
     def is_blinking(self) -> bool:
-        return self._io._blink_thread is not None or self._io._controller is not None
+        # gpiozero.RGBLight don't have effect controller, but DigitalOutputDevice does
+        return self._io._blink_thread is not None or (
+            hasattr(self._io, "_controller") and self._io._controller is not None
+        )
 
     def _blink(self, effect: str, pwm: bool):
         self.turn_off()
@@ -177,6 +180,7 @@ class RgbGpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
     def __init__(self, config: RgbLightConfig) -> None:
         """Initialize the pin."""
 
+        self._pwm = config.frequency is not None and config.frequency > 0
         self._attr_name = config.name
         self._attr_unique_id = config.unique_id
         self._attr_should_poll = False
@@ -199,6 +203,7 @@ class RgbGpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
             config.port_red,
             config.port_green,
             config.port_blue,
+            frequency=config.frequency,
             initial_value=(1, 1, 1) if config.default_state else (0, 0, 0),
         )
 
@@ -220,15 +225,25 @@ class RgbGpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
     def brightness(self, value: int) -> None:
         self._set(value, self._rgb)
 
+    def _ensure_light(self):
+        """Ensure RGB is not off and light will show then brightness is set"""
+        if self.rgb_color is RGB_OFF:
+            self._set(0, RGB_WHITE)
+
     def turn_on(self, **kwargs) -> None:
         """Turn on."""
-        self._blink_off()
+        if self.is_blinking:
+            self._io.off()  # when blinking, off will stop the effect and reset light to off
+            self._brightness = 0
+
         if ATTR_FLASH in kwargs:
+            self._ensure_light()
             short = kwargs[ATTR_FLASH] == FLASH_SHORT
-            self._blink("flash_short" if short else "flash_long", pwm=True)
+            self._blink("flash_short" if short else "flash_long", pwm=self._pwm)
         elif ATTR_EFFECT in kwargs:
+            self._ensure_light()
             effect_name = kwargs[ATTR_EFFECT]
-            self._blink(effect_name, pwm=True)
+            self._blink(effect_name, pwm=self._pwm)
         elif (
             ATTR_BRIGHTNESS in kwargs
             or ATTR_RGB_COLOR in kwargs
@@ -261,7 +276,7 @@ class RgbGpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
             self._rgb = rgb
             self._brightness = brightness
             self._io.value = value
-            self.async_write_ha_state()
+            self.schedule_update_ha_state()
             _LOGGER.debug(f"{self!r} light set to {rgb}/{brightness} ({value})")
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/gpio_integration/light.py
+++ b/custom_components/gpio_integration/light.py
@@ -200,9 +200,9 @@ class RgbGpioLight(ClosableMixin, ReprMixin, BlinkMixin, LightEntity):
         self._brightness = HIGH_BRIGHTNESS if config.default_state else 0
         self._rgb = RGB_WHITE if config.default_state else RGB_OFF
         self._io = RgbLight(
-            config.port_red,
-            config.port_green,
-            config.port_blue,
+            red=config.port_red,
+            green=config.port_green,
+            blue=config.port_blue,
             frequency=config.frequency,
             initial_value=(1, 1, 1) if config.default_state else (0, 0, 0),
         )

--- a/tests/mocked_modules.py
+++ b/tests/mocked_modules.py
@@ -74,6 +74,7 @@ sys.modules["homeassistant.components.light"].LightEntityFeature = LightEntityFe
 sys.modules["homeassistant.components.light"].ATTR_BRIGHTNESS = "A_BRIGHTNESS"
 sys.modules["homeassistant.components.light"].ATTR_EFFECT = "A_EFFECT"
 sys.modules["homeassistant.components.light"].ATTR_FLASH = "A_FLASH"
+sys.modules["homeassistant.components.light"].ATTR_RGB_COLOR = "A_RGB"
 sys.modules["homeassistant.components.light"].EFFECT_OFF = "E_OFF"
 sys.modules["homeassistant.components.light"].FLASH_SHORT = "F_SHORT"
 sys.modules["homeassistant.components.light"].FLASH_LONG = "F_LONG"

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -14,6 +14,16 @@ def get_next_pin() -> int:
     return PIN_NUMBER
 
 
+def assert_gpio_blink(pin, gpio, test: list[tuple[bool, float]]):
+    pin.states = []
+    gpio._io._blink_thread.execute_target()
+    map = gpio._io._blink_thread.zip(pin.states)
+    assert len(map) == len(test)
+    for idx in range(len(test)):
+        val = round(map[idx][0], 2)
+        assert test[idx][0] == val
+
+
 class MockedBaseEntity:
     ha_state_update_scheduled = False
     ha_state_update_scheduled_force_refresh = False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -9,7 +9,7 @@ from custom_components.gpio_integration.schemas import (
     CONF_NAME,
 )
 from custom_components.gpio_integration.schemas.pwm import PwmConfig
-from tests.mocks import get_next_pin
+from tests.mocks import assert_gpio_blink, get_next_pin
 
 
 def __create_config(port=None, default_state=False, frequency=50):
@@ -114,14 +114,6 @@ def test__GpioLight_LED_should_set_brightness(mocked_factory):
         assert gpio.is_on is False
 
 
-def _assert_blink(pin, gpio, test: list[tuple[bool, float]]):
-    pin.states = []
-    gpio._io._blink_thread.execute_target()
-    map = gpio._io._blink_thread.zip(pin.states)
-    for idx in range(len(test)):
-        assert test[idx][0] == map[idx][0]
-
-
 def test__GpioLight_should_pulse_slow(mocked_factory, mock_gpio_thread):
     number = get_next_pin()
     pin = mocked_factory.pin(number)
@@ -131,7 +123,7 @@ def test__GpioLight_should_pulse_slow(mocked_factory, mock_gpio_thread):
         assert gpio.brightness == 0
         assert gpio.is_on is False
 
-        _assert_blink(pin, gpio, [(True, 1.5), (False, 1.5)] * 4)
+        assert_gpio_blink(pin, gpio, [(True, 1.5), (False, 1.5)] * 4)
 
 
 def test__GpioLight_should_pulse_fast(mocked_factory, mock_gpio_thread):
@@ -142,7 +134,7 @@ def test__GpioLight_should_pulse_fast(mocked_factory, mock_gpio_thread):
 
         assert gpio.brightness == 0
         assert gpio.is_on is False
-        _assert_blink(pin, gpio, [(True, 1.2), (False, 1.2)] * 2)
+        assert_gpio_blink(pin, gpio, [(True, 1.2), (False, 1.2)] * 2)
 
 
 def test__GpioLight_should_effect_blink(mocked_factory, mock_gpio_thread):
@@ -154,7 +146,7 @@ def test__GpioLight_should_effect_blink(mocked_factory, mock_gpio_thread):
         assert gpio.brightness == 0
         assert gpio.is_on is False
 
-        _assert_blink(pin, gpio, [(True, 1), (False, 1)] * 200)
+        assert_gpio_blink(pin, gpio, [(True, 1), (False, 1)] * 200)
 
 
 def test__GpioLight_should_effect_off(mocked_factory, mock_gpio_thread):

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -1,6 +1,5 @@
 import pytest
 from homeassistant.components.light import ColorMode
-from homeassistant.const import CONF_PORT
 
 from custom_components.gpio_integration.light import RgbGpioLight
 from custom_components.gpio_integration.schemas import (

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -1,0 +1,244 @@
+import pytest
+from homeassistant.components.light import ColorMode
+from homeassistant.const import CONF_PORT
+
+from custom_components.gpio_integration.light import RgbGpioLight
+from custom_components.gpio_integration.schemas import (
+    CONF_DEFAULT_STATE,
+    CONF_FREQUENCY,
+    CONF_NAME,
+)
+from custom_components.gpio_integration.schemas.light import (
+    CONF_BLUE_PIN,
+    CONF_GREEN_PIN,
+    CONF_RED_PIN,
+    RgbLightConfig,
+)
+from tests.mocks import get_next_pin
+
+
+def __create_config(
+    pin_red: int = None,
+    pin_blue: int = None,
+    pim_green: int = None,
+    default_state=False,
+    frequency=50,
+):
+    return RgbLightConfig(
+        {
+            CONF_NAME: "Test Name",
+            CONF_RED_PIN: get_next_pin() if pin_red is None else pin_red,
+            CONF_BLUE_PIN: get_next_pin() if pin_blue is None else pin_blue,
+            CONF_GREEN_PIN: get_next_pin() if pim_green is None else pim_green,
+            CONF_FREQUENCY: frequency,
+            CONF_DEFAULT_STATE: default_state,
+        }
+    )
+
+
+def test__RgbLight_should_init_default_light(mocked_factory):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    with RgbGpioLight(__create_config(n1, n2, n3, frequency=0)) as gpio:
+        assert gpio.is_on is False
+        assert gpio.brightness == 0
+        assert ColorMode.ONOFF in gpio._attr_supported_color_modes
+        assert ColorMode.RGB in gpio._attr_supported_color_modes
+        assert ColorMode.BRIGHTNESS in gpio._attr_supported_color_modes
+        assert ColorMode.WHITE in gpio._attr_supported_color_modes
+        assert "Blink" in gpio._attr_effect_list
+        assert "E_OFF" in gpio._attr_effect
+        assert gpio._attr_color_mode == ColorMode.RGB
+        assert p1._function == "output"
+        assert p1._frequency is None
+        assert p2._function == "output"
+        assert p2._frequency is None
+        assert p3._function == "output"
+        assert p3._frequency is None
+
+
+def test__RgbGpioLight_LED_should_init_frequency(mocked_factory):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    with RgbGpioLight(__create_config(n1, n2, n3, frequency=200)):
+        assert p1._function == "output"
+        assert p1._frequency == 200
+        assert p2._function == "output"
+        assert p2._frequency == 200
+        assert p3._function == "output"
+        assert p3._frequency == 200
+
+
+def test__RgbGpioLight_LED_should_init_default_state(mocked_factory):
+    with RgbGpioLight(__create_config(default_state=True)) as gpio:
+        assert gpio.is_on is True
+        assert gpio.brightness == 255
+        assert gpio.ha_state_update_scheduled is False
+
+
+def test__RgbGpioLight_LED_should_turn_led_on_off(mocked_factory):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    with RgbGpioLight(__create_config(n1, n2, n3)) as gpio:
+        gpio.turn_on()
+        assert p1._state == 1
+        assert p2._state == 1
+        assert p3._state == 1
+        assert gpio.brightness == 255
+        assert gpio.is_on is True
+
+        gpio.turn_off()
+        assert p1._state == 0
+        assert p2._state == 0
+        assert p3._state == 0
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+
+
+def test__RgbGpioLight_LED_should_turn_bulb_on_off(mocked_factory):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    with RgbGpioLight(__create_config(n1, n2, n3, frequency=0)) as gpio:
+        gpio.turn_on()
+        assert p1._state is True
+        assert p2._state is True
+        assert p3._state is True
+        assert gpio.brightness == 255
+        assert gpio.is_on is True
+
+        gpio.turn_off()
+        assert p1._state is False
+        assert p2._state is False
+        assert p3._state is False
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+
+
+def test__RgbGpioLight_LED_on_off_should_write_ha(mocked_factory):
+    with RgbGpioLight(__create_config()) as gpio:
+
+        gpio.ha_state_write = False
+        gpio.turn_on()
+        assert gpio.ha_state_update_scheduled is True
+
+        gpio.ha_state_write = False
+        gpio.turn_off()
+        assert gpio.ha_state_update_scheduled is True
+
+
+def test__RgbGpioLight_LED_should_set_brightness(mocked_factory):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    with RgbGpioLight(
+        __create_config(n1, n2, n3, default_state=True, frequency=100)
+    ) as gpio:
+
+        gpio.turn_on(**{"A_BRIGHTNESS": 130})
+        assert p1._state == 0.5098
+        assert p2._state == 0.5098
+        assert p3._state == 0.5098
+        assert gpio.brightness == 130
+        assert gpio.is_on is True
+
+        gpio.turn_off(**{"A_BRIGHTNESS": 0})
+        assert p1._state == 0
+        assert p2._state == 0
+        assert p3._state == 0
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+
+
+def _assert_blink(pin, gpio, test: list[tuple[bool, float]]):
+    pin.states = []
+    gpio._io._blink_thread.execute_target()
+    map = gpio._io._blink_thread.zip(pin.states)
+    for idx in range(len(test)):
+        assert test[idx][0] == map[idx][0]
+
+
+def test__RgbGpioLight_should_pulse_slow(mocked_factory, mock_gpio_thread):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    with RgbGpioLight(__create_config(n1, n2, n3, frequency=0)) as gpio:
+        gpio.turn_on(**{"A_FLASH": "F_LONG"})
+
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+
+        _assert_blink(p1, gpio, [(True, 1.5), (False, 1.5)] * 4)
+        _assert_blink(p2, gpio, [(True, 1.5), (False, 1.5)] * 4)
+        _assert_blink(p3, gpio, [(True, 1.5), (False, 1.5)] * 4)
+
+
+def test__RgbGpioLight_should_pulse_fast(mocked_factory, mock_gpio_thread):
+    number = get_next_pin()
+    pin = mocked_factory.pin(number)
+    with RgbGpioLight(__create_config(number, frequency=0)) as gpio:
+        gpio.turn_on(**{"A_FLASH": "F_SHORT"})
+
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+        _assert_blink(pin, gpio, [(True, 1.2), (False, 1.2)] * 2)
+
+
+def test__RgbGpioLight_should_effect_blink(mocked_factory, mock_gpio_thread):
+    number = get_next_pin()
+    pin = mocked_factory.pin(number)
+    with RgbGpioLight(__create_config(number, frequency=0)) as gpio:
+        gpio.turn_on(**{"A_EFFECT": "Blink"})
+
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+
+        _assert_blink(pin, gpio, [(True, 1), (False, 1)] * 200)
+
+
+def test__RgbGpioLight_should_effect_off(mocked_factory, mock_gpio_thread):
+    number = get_next_pin()
+    with RgbGpioLight(__create_config(number, frequency=0)) as gpio:
+        gpio.turn_on(**{"A_EFFECT": "E_OFF"})
+
+        assert gpio.brightness == 0
+        assert gpio.is_on is False
+
+
+@pytest.mark.asyncio
+async def test__RgbGpioLight_will_close_pin(mocked_factory):
+    n1 = get_next_pin()
+    n2 = get_next_pin()
+    n3 = get_next_pin()
+    p1 = mocked_factory.pin(n1)
+    p2 = mocked_factory.pin(n2)
+    p3 = mocked_factory.pin(n3)
+    gpio = RgbGpioLight(__create_config(n1, n2, n3))
+
+    await gpio.async_will_remove_from_hass()
+
+    assert p1.closed is True
+    assert p2.closed is True
+    assert p3.closed is True
+    assert gpio._io is None


### PR DESCRIPTION
* Fix the _blink_off function bug that was removed in favor of _io.off() that also set the led to off state and stop the blink thread
* Add tests
* Make the RGB light both PMW and non PMW
* Allow setting of Frequency